### PR TITLE
Encountered an issue in Python 2.4

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -137,8 +137,11 @@ def main(argv):
         check_connect(host, port, warning, critical, perf_data, user, passwd)
         
 def exit_with_general_critical(e):
-    print "CRITICAL - General MongoDB Error:", e
-    sys.exit(2)
+    if isinstance(e, SystemExit):
+        sys.exit(e)
+    else:
+        print "CRITICAL - General MongoDB Error:", e
+        sys.exit(2)
 
 def check_connect(host, port, warning, critical, perf_data, user, passwd):
     warning = warning or 3


### PR DESCRIPTION
Pre-py2.5, sys.exit inherits from StandardError, so this is trapped by code that catches Exception.
