### PR TITLE
Improved notes about replication_lag check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ define service {
 
 #### Check Replication Lag
 
-This is a test that will test the replication lag of Mongo servers. It will send out a warning if the lag is over 2 seconds and a critical error if its over 5 seconds
+This is a test that will test the replication lag of Mongo servers. It will send out a warning if the lag is over 15 seconds and a critical error if its over 30 seconds. Please note that this check uses 'optime' from rs.status() which will be behind realtime as heartbeat requests between servers only occur every few seconds. Thus this check may show an apparent lag of < 10 seconds when there really isn't any. Use larger values for reliable monitoring.
 
 <pre><code>
 define service {
     use                 generic-service
     hostgroup_name          Mongo Servers
     service_description     Mongo Replication Lag
-    check_command           check_mongodb!replication_lag!27017!2!5
+    check_command           check_mongodb!replication_lag!27017!15!30
 }
 </code></pre>
 


### PR DESCRIPTION
Hi!

We've been using your awesome replication_lag check with it's recommended 2 sec warning/5 sec critical in production for a few days now and have observed it going over those thresholds multiple times on a mongo setup that's under very little load. After verifying it's not an issue on our end and looking at how the plugin works I came across

http://www.mongodb.org/display/DOCS/Replica+Set+Commands#ReplicaSetCommands-optime%2CoptimeDate

which seems to mirror what we are seeing in that there's lag being reported which doesn't actually exist.
