### PR TITLE
replication lag check throwing exception since upgrade to mongod 2.0.2 running on default port

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -202,6 +202,9 @@ def check_rep_lag(con, warning, critical, perf_data):
             rs_conf = con.local.system.replset.find_one()
 
             for member in rs_conf['members']:
+                # mongod 2.0.2 does not include the port if it is running on the default port
+                if member['host'].find(':') == -1:
+                    member['host'] = member['host'] + ":27017" 
                 if member.get('slaveDelay') is not None:
                     slaveDelays[member['host']] = member.get('slaveDelay')
                 else:


### PR DESCRIPTION
Since upgrading our mongodb servers to 2.0.2, the replication lag checks started throwing an exception:

`CRITICAL - General MongoDB Error: u'fake.hostname.net:27017'`

The host is in the `slaveDelays` collection but it doesn't include the port. The pull request appends the default mongo port if there isn't one.

Thanks
