### PR TITLE
Match a longer string on exception. 

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -89,7 +89,7 @@ def main(argv):
             db = con["admin"]
             db.authenticate(user, passwd)
     except Exception, e:
-        if isinstance(e,pymongo.errors.AutoReconnect) and str(e).find("arbiter") != -1:
+        if isinstance(e,pymongo.errors.AutoReconnect) and str(e).find(" is an arbiter") != -1:
             # We got a pymongo AutoReconnect exception that tells us we connected to an Arbiter Server
             # This means: Arbiter is reachable and can answer requests/votes - this is all we need to know from an arbiter
             print "OK - State: 7 (Arbiter)"


### PR DESCRIPTION
Fixes a bug where a hostname that contains "arbiter" always gets OK.
