### PR TITLE
Fixed replication_lag check & slave_ok deprecation warning

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -221,22 +221,21 @@ def check_rep_lag(con, host, warning, critical, perf_data):
 			sys.exit(0)
 		
 		# Find the difference in optime between current node and PRIMARY
-		optime_lag = abs(primary_node[1] - host_node["optimeDate"])
+        optime_lag = abs(primary_node[1] - host_node["optimeDate"])
         lag = str(optime_lag.seconds)
 		if optime_lag.seconds > critical:
-			print "CRITICAL - lag is " + lag + " seconds"
-			sys.exit(2)
-		elif lag > warning:
-			print "WARNING - lag is " + lag + " seconds"
-			sys.exit(1)
-		else:
-			print "OK - lag is " + lag + " seconds"
-			sys.exit(0)
-			
-    except Exception, e:
-    	print e
-        exit_with_general_critical(e)
+            print "CRITICAL - lag is " + lag + " seconds"
+            sys.exit(2)
+        elif lag > warning:
+            print "WARNING - lag is " + lag + " seconds"
+            sys.exit(1)
+        else:
+            print "OK - lag is " + lag + " seconds"
+            sys.exit(0)
 
+    except Exception, e:
+        print e
+        exit_with_general_critical(e)
 
 def check_memory(con, warning, critical, perf_data):
     #


### PR DESCRIPTION
The previous replication lag check does not work correctly and used data ("local.slaves") that is unsupported. According to 10gen, the local.slaves "collection is not for public use and just part of the replica set internals". Specifically, the local.slaves collection will include secondary nodes that have been removed from the replica set. In addition, it didn't make a lot of sense to only have the primary report replication problems and have the secondaries report "OK", even if they were behind in replication.

The first commit replaces the old logic with a simple use of the replSetGetStatus function in MongoDB. Primaries now always report OK, since they cannot possibly be behind in replication. Secondaries report WARNING or CRITICAL if they are more than X seconds behind the primary.

The remaining commits deal with the fact that passing the "slave_ok" parameter to pymongo.Connection() is deprecated as of 2.1 and throws a warning. Since python displays the warning on standard out, Nagios reads that and believes the request has failed. The commits add support for eliminating the "slave_ok" parameter and setting db.read_preference, but only for pymongo version 2.1 and later.
