### PR TITLE
Fix issue with replication lag check and whitespace issues

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -226,7 +226,7 @@ def check_rep_lag(con, host, warning, critical, perf_data):
         if optime_lag.seconds > critical:
             print "CRITICAL - lag is " + lag + " seconds"
             sys.exit(2)
-        elif lag > warning:
+        elif optime_lag.seconds > warning:
             print "WARNING - lag is " + lag + " seconds"
             sys.exit(1)
         else:


### PR DESCRIPTION
Was trying to set up this check today and ran into a few issues.

First, there were some whitespace issues that was causing Python to choke.

Second, and not in here, was getting a `'module' object has no attribute 'version'` error for the `pymongo.version` checks.  I don't really use Python, so I just took out the version checks and it worked.  The pymongo docs say it should have a `pymongo.version`, but not sure why it didn't work.

And finally, the replication lag check was always returning a warning.  Found it was because the if statement was comparing a number against a string, while the check for the critical level was doing it right.
