### PR TITLE
Support for pymongo >= 1.9

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -35,9 +35,9 @@ except ImportError, e:
 
 # As of pymongo v 1.9 the SON API is part of the BSON package, therefore attempt
 # to import from there and fall back to pymongo in cases of older pymongo
-try:
-    import bcson.son as son
-except ImportError:
+if pymongo.version >= "1.9":
+    import bson.son as son
+else:
     import pymongo.son as son
 
 #


### PR DESCRIPTION
Moving the import to attempt the new location for newer versions of pymongo
but fall back to the pymongo version to support the older API
