### PR TITLE
master-add-primary-replica-check: fixed docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Replace your-replicaset with the name of your replicaset
 define service {
       use                     generic-service
       hostgroup_name          Mongo Servers
-      service_description     MongoDB Database size your-database
-      check_command           check_mongodb_replicaset!database_size!27017!300!500!your-replicaset
+      service_description     MongoDB Replicaset Master Monitor: your-replicaset
+      check_command           check_mongodb_replicaset!replica_primary!27017!0!1!your-replicaset
 }
 </code></pre>


### PR DESCRIPTION
Fixes to the documentation to correct missed values due to using
cut and paste of prior example.  Documentation now has proper
values for all fields in the primary replicaset check.
