### PR TITLE
fix for division by zero in replication_lag_percent action

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -406,7 +406,10 @@ def check_rep_lag(con, host, warning, critical, percent, perf_data,max_lag):
                 if err!=0:
                     return err 
                 primary_timediff=replication_get_time_diff(con)
-                lag=int(float(lag)/float(primary_timediff)*100)
+                if primary_timediff!=0: 
+                    lag=int(float(lag)/float(primary_timediff)*100)
+                else:
+                    lag=0
                 message = "Lag is "+str(lag) + " percents"
                 message += performance_data(perf_data,[(lag,"replication_lag_percent",warning, critical)])
             else:


### PR DESCRIPTION
It happens for my newly installed replica set, that there is a big fat zero returned from replication_get_time_diff - This results in a division by zero, which generates an alarm...
