### PR TITLE
Fixing an error with "queries_per_second" action on a replicaset.

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -250,7 +250,7 @@ def mongo_connect(host=None, port=None, ssl=False, user=None, passwd=None, repli
         # ssl connection for pymongo > 2.1
         if pymongo.version >= "2.1":
             if replica is None:
-                con = pymongo.Connection(host, port, read_preference=pymongo.ReadPreference.SECONDARY, ssl=ssl, network_timeout=10)
+                con = pymongo.MongoClient(host, port)
             else:
                 con = pymongo.Connection(host, port, read_preference=pymongo.ReadPreference.SECONDARY, ssl=ssl, replicaSet=replica, network_timeout=10)
         else:


### PR DESCRIPTION
This is the fix for the error

CRITICAL - General MongoDB Error: not master

While working on a replicaset with "queries_per_second" action.
