### PR TITLE
Use the actual hostname to identify replica set members

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -28,6 +28,7 @@ import optparse
 import textwrap
 import re
 import os
+import socket
 
 try:
     import pymongo
@@ -325,6 +326,10 @@ def check_connections(con, warning, critical, perf_data):
 
 
 def check_rep_lag(con, host, port, warning, critical, percent, perf_data, max_lag, user, passwd):
+    # Use actual hostname to find replica set member when connecting locally
+    if "127.0.0.1" == host:
+        host = socket.gethostname()
+
     if percent:
         warning = warning or 50
         critical = critical or 75


### PR DESCRIPTION
If you run the script locally on the MongoDB node itself "host"
will default to 127.0.0.1. In a production environment 127.0.0.1
is not the host specified in the replica set configuration which means,
currently, check_rep_lag() returns an "Unable to find host" error in
such a case.

Specifying the hostname as a command line argument, also for local
runs, isn't an alternative as it affects the authentication scheme:
local connects via 127.0.0.1 don't (by default) require authentication
while connects specifying a hostname can - the very reason why someone
might prefer to run the check script locally, not remotely.
