### PR TITLE
Set slaveOk=True for MongoClient, too.

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -255,7 +255,7 @@ def mongo_connect(host=None, port=None, ssl=False, user=None, passwd=None, repli
         # ssl connection for pymongo > 2.3
         if pymongo.version >= "2.3":
             if replica is None:
-                con = pymongo.MongoClient(host, port)
+                con = pymongo.MongoClient(host, port, slaveOk=True)
             else:
                 con = pymongo.Connection(host, port, read_preference=pymongo.ReadPreference.SECONDARY, ssl=ssl, replicaSet=replica, network_timeout=10)
         else:


### PR DESCRIPTION
Hi,

I've added slaveOk to the MongoClient-API as well. I think this is a valid change as it renders this code path equal to the code path for older installations.

Christian
