### PR TITLE
Get mongo to tell us the replica set name when connecting locally

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -28,7 +28,6 @@ import optparse
 import textwrap
 import re
 import os
-import socket
 
 try:
     import pymongo
@@ -330,9 +329,9 @@ def check_connections(con, warning, critical, perf_data):
 
 
 def check_rep_lag(con, host, port, warning, critical, percent, perf_data, max_lag, user, passwd):
-    # Use actual hostname to find replica set member when connecting locally
+    # Get mongo to tell us replica set member name when connecting locally
     if "127.0.0.1" == host:
-        host = socket.gethostname()
+        host = con.admin.command("ismaster","1")["me"].split(':')[0]
 
     if percent:
         warning = warning or 50


### PR DESCRIPTION
socket.gethostname() won't always match the local name of the replica
set member; one example is when gethostname() returns a shortname, but
the replica set member name is an FQDN.

In a previous version of the code (before 32409ca0), we asked mongo to
tell us which member we were, by querying the "me" key from the hash
returned by the "ismaster" command.  This seems like the Right Thing to
do -- rather than guess what name we have, just get mongo to tell us.
