### PR TITLE
Only read timestamps from oplog, making the check work with invalid unicode data in the log

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -69,9 +69,9 @@ def performance_data(perf_data, params):
                 warning = warning or 0
                 critical = critical or 0
                 data += ";%s;%s" % (warning, critical)
-                
+
             data += " "
-            
+
     return data
 
 
@@ -1368,8 +1368,8 @@ def replication_get_time_diff(con):
     ol = local.system.namespaces.find_one({"name": "local.oplog.$main"})
     if ol:
         col = 'oplog.$main'
-    firstc = local[col].find().sort("$natural", 1).limit(1)
-    lastc = local[col].find().sort("$natural", -1).limit(1)
+    firstc = local[col].find(fields = ["ts"]).sort("$natural", 1).limit(1)
+    lastc = local[col].find(fields = ["ts"]).sort("$natural", -1).limit(1)
     first = firstc.next()
     last = lastc.next()
     tfirst = first["ts"]

--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -940,8 +940,8 @@ def check_oplog(con, warning, critical, perf_data):
         ol_storage_size = data['storageSize']
         ol_used_storage = int(float(ol_size) / ol_storage_size * 100 + 1)
         ol = con.local[oplog]
-        firstc = ol.find().sort("$natural", pymongo.ASCENDING).limit(1)[0]['ts']
-        lastc = ol.find().sort("$natural", pymongo.DESCENDING).limit(1)[0]['ts']
+        firstc = ol.find(fields=["ts"]).sort("$natural", pymongo.ASCENDING).limit(1)[0]['ts']
+        lastc = ol.find(fields=["ts"]).sort("$natural", pymongo.DESCENDING).limit(1)[0]['ts']
         time_in_oplog = (lastc.as_datetime() - firstc.as_datetime())
         message = "Oplog saves " + str(time_in_oplog) + " %d%% used" % ol_used_storage
         try:  # work starting from python2.7


### PR DESCRIPTION
In cases when some collection in MongoDb contains invalid unicode data, that data is replicated via the oplog collection and if the invalid record ends up being the first or the last one in the log, all replication-related checks blow up with invalid unicode errors (see https://github.com/10gen-labs/mongo-connector/issues/101 for details):

```
CRITICAL - General MongoDB Error: 'utf8' codec can't decode byte 0xc7 in position 0: invalid continuation byte
```

My small change makes the check script only read the timestamp field from the log so we never touch the actual user data in the log and never blow up on those errors. This has been tested on Swiftype.com servers and seems to be working as expected.
