### PR TITLE
use the self flag in check_rep_lag instead of crazy host matching

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -377,7 +377,7 @@ def check_rep_lag(con, host, port, warning, critical, percent, perf_data, max_la
             for member in rs_status["members"]:
                 if member["stateStr"] == "PRIMARY":
                     primary_node = member
-                if member["name"].split(':')[0] == host and int(member["name"].split(':')[1]) == port:
+                if member.get('self') == True
                     host_node = member
 
             # Check if we're in the middle of an election and don't have a primary


### PR DESCRIPTION
found this because our mongo cluster has FQDNs in rs.conf(), whereas nagios passes an IP address to the -H argument by default