### PR TITLE
syntax: missing colon

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -377,7 +377,7 @@ def check_rep_lag(con, host, port, warning, critical, percent, perf_data, max_la
             for member in rs_status["members"]:
                 if member["stateStr"] == "PRIMARY":
                     primary_node = member
-                if member.get('self') == True
+                if member.get('self') == True:
                     host_node = member
 
             # Check if we're in the middle of an election and don't have a primary


### PR DESCRIPTION
Simple syntax fix fixes the (now) broken plugin! :shipit: 