### PR TITLE
Check database authentication against database

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -177,7 +177,7 @@ def main(argv):
     # moving the login up here and passing in the connection
     #
     start = time.time()
-    err, con = mongo_connect(host, port, ssl, user, passwd, replicaset)
+    err, con = mongo_connect(host, port, ssl, user, passwd, replicaset, database)
     if err != 0:
         return err
 
@@ -255,7 +255,7 @@ def main(argv):
         return check_connect(host, port, warning, critical, perf_data, user, passwd, conn_time)
 
 
-def mongo_connect(host=None, port=None, ssl=False, user=None, passwd=None, replica=None):
+def mongo_connect(host=None, port=None, ssl=False, user=None, passwd=None, replica=None, database=None):
     try:
         # ssl connection for pymongo > 2.3
         if pymongo.version >= "2.3":
@@ -271,7 +271,7 @@ def mongo_connect(host=None, port=None, ssl=False, user=None, passwd=None, repli
                 #con = pymongo.Connection(host, port, slave_okay=True, replicaSet=replica, network_timeout=10)
 
         if user and passwd:
-            db = con["admin"]
+            db = con[database]
             if not db.authenticate(user, passwd):
                 sys.exit("Username/Password incorrect")
     except Exception, e:


### PR DESCRIPTION
Currently authentication check is always made on admin database even if `--database` option is given.
This behavior cause authentication error if the user only doesn't have admin databse access.
