### PR TITLE
mongo 3.0 changed error code and text

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -354,7 +354,7 @@ def check_rep_lag(con, host, port, warning, critical, percent, perf_data, max_la
         try:
             rs_status = con.admin.command("replSetGetStatus")
         except pymongo.errors.OperationFailure, e:
-            if e.code == None and str(e).find('failed: not running with --replSet"'):
+            if ((e.code == None and str(e).find('failed: not running with --replSet"')) or (e.code == 76 and str(e).find('not running with --replSet"'))):
                 print "OK - Not running with replSet"
                 return 0
 
@@ -723,7 +723,7 @@ def check_replset_state(con, perf_data, warning="", critical=""):
                 data = con.admin.command(son.SON([('replSetGetStatus', 1)]))
             state = int(data['myState'])
         except pymongo.errors.OperationFailure, e:
-            if e.code == None and str(e).find('failed: not running with --replSet"'):
+            if ((e.code == None and str(e).find('failed: not running with --replSet"')) or (e.code == 76 and str(e).find('not running with --replSet"'))):
                 state = -1
 
         if state == 8:


### PR DESCRIPTION
When checking a mongodb that is not in a replicaset, 2.8 and earlier reply "failed: not running with --replSet" with code None.
The new 3.0 mongodbs reply simply "not running with --replSet" with code 76.

This change adds support for the 3.0 values, so the check does not return "General MongoDB Error: local variable 'state' referenced before assignment" when checking mongodb 3.0+ servers that are not in a replicaset.