### PR TITLE
Monitoring updates only write to the 'nagios' db and not 'local'

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,20 +235,6 @@ define service {
 </code></pre>
 
 
-#### Check utilization of a database
-This will check the utilization of a database as the percentage of data size vs the size of the database on disk.
-This is useful for keeping track of growth of a particular database and determining when a data compress or repair
-should be considered.
-Replace your-database with the name of your database
-<pre><code>
-define service {
-      use                     generic-service
-      hostgroup_name          Mongo Servers
-      service_description     MongoDB Database utilization your-database
-      check_command           check_mongodb_database!database_utilization!27017!25!10!your-database
-}
-</code></pre>
-
 
 #### Check index size of a database
 This will check the index size of a database. Overlarge indexes eat up memory and indicate a need for compaction.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,20 @@ define service {
 </code></pre>
 
 
+#### Check utilization of a database
+This will check the utilization of a database as the percentage of data size vs the size of the database on disk.
+This is useful for keeping track of growth of a particular database and determining when a data compress or repair
+should be considered.
+Replace your-database with the name of your database
+<pre><code>
+define service {
+      use                     generic-service
+      hostgroup_name          Mongo Servers
+      service_description     MongoDB Database utilization your-database
+      check_command           check_mongodb_database!database_utilization!27017!25!10!your-database
+}
+</code></pre>
+
 
 #### Check index size of a database
 This will check the index size of a database. Overlarge indexes eat up memory and indicate a need for compaction.


### PR DESCRIPTION
This Pull Request is in response to issues #115, #114 and #170 where the plugin is writing to multiple databases within Mongo.

The error: "General MongoDB Error: not authorized for update on local.nagios_check" will get raised if the user has has been granted the following permissions:

MongoDb 2.4:
'roles' : [ 'readAnyDatabase', 'clusterAdmin' ],
'otherDBRoles' : { 'nagios' : [ 'readWrite' ] }

MongoDb 2.6+:
'roles' : [ 'readAnyDatabase', 'clusterMonitor' ],
'otherDBRoles' : { 'nagios' : [ 'readWrite' ] }

This PR fixes this by making all updates to the 'nagios' database only instead of local.