### PR TITLE
Mongodb 3 compatibility, variable authdb and arbiter status fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,20 +235,6 @@ define service {
 </code></pre>
 
 
-#### Check utilization of a database
-This will check the utilization of a database as the percentage of data size vs the size of the database on disk.
-This is useful for keeping track of growth of a particular database and determining when a data compress or repair
-should be considered.
-Replace your-database with the name of your database
-<pre><code>
-define service {
-      use                     generic-service
-      hostgroup_name          Mongo Servers
-      service_description     MongoDB Database utilization your-database
-      check_command           check_mongodb_database!database_utilization!27017!25!10!your-database
-}
-</code></pre>
-
 
 #### Check index size of a database
 This will check the index size of a database. Overlarge indexes eat up memory and indicate a need for compaction.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,20 @@ define service {
 </code></pre>
 
 
+#### Check utilization of a database
+This will check the utilization of a database as the percentage of data size vs the size of the database on disk.
+This is useful for keeping track of growth of a particular database and determining when a data compress or repair
+should be considered.
+Replace your-database with the name of your database
+<pre><code>
+define service {
+      use                     generic-service
+      hostgroup_name          Mongo Servers
+      service_description     MongoDB Database utilization your-database
+      check_command           check_mongodb_database!database_utilization!27017!25!10!your-database
+}
+</code></pre>
+
 
 #### Check index size of a database
 This will check the index size of a database. Overlarge indexes eat up memory and indicate a need for compaction.

--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -133,7 +133,7 @@ def main(argv):
     p.add_option('-A', '--action', action='store', type='choice', dest='action', default='connect', help='The action you want to take',
                  choices=['connect', 'connections', 'replication_lag', 'replication_lag_percent', 'replset_state', 'memory', 'memory_mapped', 'lock',
                           'flushing', 'last_flush_time', 'index_miss_ratio', 'databases', 'collections', 'database_size', 'database_indexes', 'collection_indexes', 'collection_size',
-                          'collection_storageSize', 'queues', 'oplog', 'journal_commits_in_wl', 'write_data_files', 'journaled', 'opcounters', 'current_lock', 'replica_primary', 
+                          'collection_storageSize', 'queues', 'oplog', 'journal_commits_in_wl', 'write_data_files', 'journaled', 'opcounters', 'current_lock', 'replica_primary',
                           'page_faults', 'asserts', 'queries_per_second', 'page_faults', 'chunks_balance', 'connect_primary', 'collection_state', 'row_count', 'replset_quorum'])
     p.add_option('--max-lag', action='store_true', dest='max_lag', default=False, help='Get max replication lag (for replication_lag action only)')
     p.add_option('--mapped-memory', action='store_true', dest='mapped_memory', default=False, help='Get mapped memory instead of resident (if resident memory can not be read)')
@@ -145,8 +145,8 @@ def main(argv):
     p.add_option('-q', '--querytype', action='store', dest='query_type', default='query', help='The query type to check [query|insert|update|delete|getmore|command] from queries_per_second')
     p.add_option('-c', '--collection', action='store', dest='collection', default='admin', help='Specify the collection to check')
     p.add_option('-T', '--time', action='store', type='int', dest='sample_time', default=1, help='Time used to sample number of pages faults')
-    p.add_option('-M', '--mongoversion', action='store', type='choice', dest='mongo_version', default='2', help='The MongoDB version you are talking with, either 2 or 3',
-      choices=['2','3'])
+    p.add_option('-M', '--mongoversion', action='store', type='choice', dest='mongo_version', default=0, help='The MongoDB version you are talking with, either 2 or 3',
+
 
     options, arguments = p.parse_args()
     host = options.host
@@ -166,7 +166,6 @@ def main(argv):
     action = options.action
     perf_data = options.perf_data
     max_lag = options.max_lag
-    mongo_version = options.mongo_version
     database = options.database
     ssl = options.ssl
     replicaset = options.replicaset
@@ -183,6 +182,15 @@ def main(argv):
     err, con = mongo_connect(host, port, ssl, user, passwd, replicaset)
     if err != 0:
         return err
+
+    # Autodetect mongo-version and force pymongo to let us know if it can connect or not.
+    err, mongo_version = check_version(con)
+    if err != 0:
+        return err
+
+    # Legacy support for -M. If -M is set force mongo_version to that.
+    if options.mongo_version != 0:
+        mongo_version = int(options.mongo_version)
 
     conn_time = time.time() - start
     conn_time = round(conn_time, 0)
@@ -310,6 +318,14 @@ def set_read_preference(db):
         db.read_preference = pymongo.ReadPreference.SECONDARY
 
 
+def check_version(con):
+    try:
+        server_info = con.server_info()
+    except Exception, e:
+        return exit_with_general_critical(e), None
+    return 0, int(server_info['version'].split('.')[0].strip())
+
+
 def check_connect(host, port, warning, critical, perf_data, user, passwd, conn_time):
     warning = warning or 3
     critical = critical or 6
@@ -344,7 +360,7 @@ def check_rep_lag(con, host, port, warning, critical, percent, perf_data, max_la
     if "127.0.0.1" == host:
         if not "me" in con.admin.command("ismaster","1").keys():
             print "OK - This is not replicated MongoDB"
-            sys.exit(3)        
+            sys.exit(3)
 
         host = con.admin.command("ismaster","1")["me"].split(':')[0]
 
@@ -518,7 +534,7 @@ def check_memory(con, warning, critical, perf_data, mapped_memory, host):
     # memory used by Mongodb is ok or not.
     meminfo = open('/proc/meminfo').read()
     matched = re.search(r'^MemTotal:\s+(\d+)', meminfo)
-    if matched: 
+    if matched:
         mem_total_kB = int(matched.groups()[0])
 
     if host != "127.0.0.1" and not warning:
@@ -624,7 +640,7 @@ def check_memory_mapped(con, warning, critical, perf_data):
 def check_lock(con, warning, critical, perf_data, mongo_version):
     warning = warning or 10
     critical = critical or 30
-    if mongo_version == "2":
+    if mongo_version == 2:
         try:
             data = get_server_status(con)
             lockTime = data['globalLock']['lockTime']
@@ -679,14 +695,11 @@ def index_miss_ratio(con, warning, critical, perf_data):
         data = get_server_status(con)
 
         try:
-            serverVersion = tuple(data['version'].split('.'))
-            if serverVersion >= tuple("3.0.0".split(".")):
-                print "FAIL - Mongo3 doesn't report on Index Miss Ratio"
-                return 1
-            elif serverVersion >= tuple("2.4.0".split(".")):
-                miss_ratio = float(data['indexCounters']['btree']['missRatio'])
-            else:
+            serverVersion = tuple(con.server_info()['version'].split('.'))
+            if serverVersion >= tuple("2.4.0".split(".")):
                 miss_ratio = float(data['indexCounters']['missRatio'])
+            else:
+                miss_ratio = float(data['indexCounters']['btree']['missRatio'])
         except KeyError:
             not_supported_msg = "not supported on this platform"
             if data['indexCounters'].has_key('note'):
@@ -1010,7 +1023,7 @@ def check_queries_per_second(con, query_type, warning, critical, perf_data, mong
             query_per_sec = float(diff_query) / float(diff_ts)
 
             # update the count now
-            if mongo_version == "2":
+            if mongo_version == 2:
                 db.nagios_check.update({u'_id': last_count['_id']}, {'$set': {"data.%s" % query_type: {'count': num, 'ts': int(time.time())}}})
             else:
                 db.nagios_check.update_one({u'_id': last_count['_id']}, {'$set': {"data.%s" % query_type: {'count': num, 'ts': int(time.time())}}})
@@ -1022,7 +1035,7 @@ def check_queries_per_second(con, query_type, warning, critical, perf_data, mong
             # since it is the first run insert it
             query_per_sec = 0
             message = "First run of check.. no data"
-            if mongo_version == "2":
+            if mongo_version == 2:
                 db.nagios_check.update({u'_id': last_count['_id']}, {'$set': {"data.%s" % query_type: {'count': num, 'ts': int(time.time())}}})
             else:
                 db.nagios_check.update_one({u'_id': last_count['_id']}, {'$set': {"data.%s" % query_type: {'count': num, 'ts': int(time.time())}}})
@@ -1032,9 +1045,9 @@ def check_queries_per_second(con, query_type, warning, critical, perf_data, mong
             # since it is the first run insert it
             query_per_sec = 0
             message = "First run of check.. no data"
-            if mongo_version == "2":
+            if mongo_version == 2:
                 db.nagios_check.insert({'check': 'query_counts', 'data': {query_type: {'count': num, 'ts': int(time.time())}}})
-            else:            
+            else:
                 db.nagios_check.insert_one({'check': 'query_counts', 'data': {query_type: {'count': num, 'ts': int(time.time())}}})
 
         return check_levels(query_per_sec, warning, critical, message)
@@ -1291,9 +1304,9 @@ def check_replica_primary(con, host, warning, critical, perf_data, replicaset, m
         saved_primary = "None"
     if current_primary != saved_primary:
         last_primary_server_record = {"server": current_primary}
-        if mongo_version == "2":
+        if mongo_version == 2:
             db.last_primary_server.update({"_id": "last_primary"}, {"$set": last_primary_server_record}, upsert=True, safe=True)
-        else:        
+        else:
             db.last_primary_server.update_one({"_id": "last_primary"}, {"$set": last_primary_server_record}, upsert=True, safe=True)
         message = "Primary server has changed from %s to %s" % (saved_primary, current_primary)
         primary_status = 1

--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -128,6 +128,7 @@ def main(argv):
     p.add_option('-P', '--port', action='store', type='int', dest='port', default=27017, help='The port mongodb is running on')
     p.add_option('-u', '--user', action='store', type='string', dest='user', default=None, help='The username you want to login as')
     p.add_option('-p', '--pass', action='store', type='string', dest='passwd', default=None, help='The password you want to use for that user')
+    p.add_option('-a', '--authdb', action='store', type='string', dest='authdb', default='admin', help='The database you want to authenticate against')
     p.add_option('-W', '--warning', action='store', dest='warning', default=None, help='The warning threshold you want to set')
     p.add_option('-C', '--critical', action='store', dest='critical', default=None, help='The critical threshold you want to set')
     p.add_option('-A', '--action', action='store', type='choice', dest='action', default='connect', help='The action you want to take',
@@ -153,6 +154,7 @@ def main(argv):
     port = options.port
     user = options.user
     passwd = options.passwd
+    authdb = options.authdb
     query_type = options.query_type
     collection = options.collection
     sample_time = options.sample_time
@@ -179,7 +181,7 @@ def main(argv):
     # moving the login up here and passing in the connection
     #
     start = time.time()
-    err, con = mongo_connect(host, port, ssl, user, passwd, replicaset)
+    err, con = mongo_connect(host, port, ssl, user, passwd, replicaset, authdb)
     if err != 0:
         return err
 
@@ -268,7 +270,7 @@ def main(argv):
         return check_connect(host, port, warning, critical, perf_data, user, passwd, conn_time)
 
 
-def mongo_connect(host=None, port=None, ssl=False, user=None, passwd=None, replica=None):
+def mongo_connect(host=None, port=None, ssl=False, user=None, passwd=None, replica=None, authdb="admin"):
     try:
         # ssl connection for pymongo > 2.3
         if pymongo.version >= "2.3":
@@ -284,7 +286,7 @@ def mongo_connect(host=None, port=None, ssl=False, user=None, passwd=None, repli
                 #con = pymongo.Connection(host, port, slave_okay=True, replicaSet=replica, network_timeout=10)
 
         if user and passwd:
-            db = con["admin"]
+            db = con[authdb]
             if not db.authenticate(user, passwd):
                 sys.exit("Username/Password incorrect")
     except Exception, e:


### PR DESCRIPTION
This pull request includes changes to:
1.  allow for a variable authdb instead of just admin
2. Better determination if a node is an Arbiter and return relevant status
3. Remove mongo_version parameter and determine version from the connection
4. Misc Mongo 3 compatibility fixes for index_miss_ratio, global lock and flushing