### PR TITLE
Fixed problem where connections to masters when checking secondaries …

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -206,7 +206,7 @@ def main(argv):
     elif action == "replication_lag":
         return check_rep_lag(con, host, warning, critical, False, perf_data, max_lag, user, passwd)
     elif action == "replication_lag_percent":
-        return check_rep_lag(con, host, warning, critical, True, perf_data, max_lag, user, passwd)
+        return check_rep_lag(con, host, warning, critical, True, perf_data, max_lag, user, passwd, ssl, insecure, cert_file)
     elif action == "replset_state":
         return check_replset_state(con, perf_data, warning, critical)
     elif action == "memory":
@@ -389,7 +389,7 @@ def check_connections(con, warning, critical, perf_data):
         return exit_with_general_critical(e)
 
 
-def check_rep_lag(con, host, warning, critical, percent, perf_data, max_lag, user, passwd):
+def check_rep_lag(con, host, warning, critical, percent, perf_data, max_lag, user, passwd, ssl=None, insecure=None, cert_file=None):
     # Get mongo to tell us replica set member name when connecting locally
     if "127.0.0.1" == host:
         if not "me" in con.admin.command("ismaster","1").keys():
@@ -498,7 +498,7 @@ def check_rep_lag(con, host, warning, critical, percent, perf_data, max_lag, use
                 lag = float(optime_lag.seconds + optime_lag.days * 24 * 3600)
 
             if percent:
-                err, con = mongo_connect(primary_node['name'].split(':')[0], int(primary_node['name'].split(':')[1]), False, user, passwd)
+                err, con = mongo_connect(primary_node['name'].split(':')[0], int(primary_node['name'].split(':')[1]), ssl, user, passwd, None, None, insecure, cert_file)
                 if err != 0:
                     return err
                 primary_timediff = replication_get_time_diff(con)


### PR DESCRIPTION
…for lag percent did not use the same connection options as the initial connection to the secondary

Running a command like this:
`# /usr/local/nagios/libexec/nagios-plugin-mongodb/check_mongodb.py -H <some secondary host> -W 50 -C 90 -A replication_lag_percent -D -s -P 27000 --insecure -f </path/to/client/cert>`

Resulted in a long wait and this message:
`CRITICAL - Connection to Mongo server on <some primary host> has failed`

Doing a keyboard interrupt while waiting for the command to complete:

`^CTraceback (most recent call last):
  File "/usr/local/nagios/libexec/nagios-plugin-mongodb/check_mongodb.py", line 1587, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/usr/local/nagios/libexec/nagios-plugin-mongodb/check_mongodb.py", line 209, in main
    return check_rep_lag(con, host, warning, critical, True, perf_data, max_lag, user, passwd)
  File "/usr/local/nagios/libexec/nagios-plugin-mongodb/check_mongodb.py", line 501, in check_rep_lag
    err, con = mongo_connect(primary_node['name'].split(':')[0], int(primary_node['name'].split(':')[1]), False, user, passwd)
  File "/usr/local/nagios/libexec/nagios-plugin-mongodb/check_mongodb.py", line 308, in mongo_connect
    result = con.admin.command("ismaster")
  File "/usr/lib64/python2.7/site-packages/pymongo/database.py", line 478, in command
    with client._socket_for_reads(read_preference) as (sock_info, slave_ok):
  File "/usr/lib64/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/usr/lib64/python2.7/site-packages/pymongo/mongo_client.py", line 798, in _socket_for_reads
    with self._get_socket(read_preference) as sock_info:
  File "/usr/lib64/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/usr/lib64/python2.7/site-packages/pymongo/mongo_client.py", line 762, in _get_socket
    server = self._get_topology().select_server(selector)
  File "/usr/lib64/python2.7/site-packages/pymongo/topology.py", line 210, in select_server
    address))
  File "/usr/lib64/python2.7/site-packages/pymongo/topology.py", line 195, in select_servers
    self._condition.wait(common.MIN_HEARTBEAT_INTERVAL)
  File "/usr/lib64/python2.7/threading.py", line 361, in wait
    _sleep(delay)
KeyboardInterrupt`

I saw this hanging in a very similar manner while working on my last PR when connecting to a host that requires SSL when SSL was not specified on the command line. After editing the three lines here, the command completes successfully:

`$ ./check_mongodb.py -H <some client host> -W 50 -C 90 -A replication_lag_percent -D -s -P 27000 --insecure -f <some/cert>
OK - Lag is 0 percents |replication_lag_percent=0;50.0;90.0`