### PR TITLE
Fix format() for Python 2.6

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -449,7 +449,7 @@ def check_rep_lag(con, host, port, warning, critical, percent, perf_data, max_la
             for member in rs_status["members"]:
                 if member["stateStr"] == "PRIMARY":
                     primary_node = member
-                if member.get('name') == "{}:{}".format(host, port):
+                if member.get('name') == "{0}:{1}".format(host, port):
                     host_node = member
 
             # Check if we're in the middle of an election and don't have a primary


### PR DESCRIPTION
Without this python 2.6 will return `CRITICAL - General MongoDB Error: zero length field name in format`

https://stackoverflow.com/questions/21034954/valueerror-zero-length-field-name-in-format-in-python2-6-6