### PR TITLE
Authenticate the connection when using x509 auth

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -314,6 +314,10 @@ def mongo_connect(host=None, port=None, ssl=False, user=None, passwd=None, repli
             else:
                 con = pymongo.Connection(host, port, slave_okay=True, network_timeout=10)
 
+        # we must authenticate the connection, otherwise we won't be able to perform certain operations
+        if ssl_cert and ssl_ca_cert_file and user:
+            con.the_database.authenticate(user, mechanism='MONGODB-X509')
+
         try:
           result = con.admin.command("ismaster")
         except ConnectionFailure:


### PR DESCRIPTION
When using x509 auth against the '' database, it's necessary to authenticate the connection, otherwise you can get permission denied errors even when the x509 user has the needed roles. For example, before adding this line I was getting 'CRITICAL - General MongoDB Error: database error: not authorized for query on local.system.replset'