### PR TITLE
Fix Replica Lag reset to 0 at the turn of a day

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -485,7 +485,7 @@ def check_rep_lag(con, host, port, warning, critical, percent, perf_data, max_la
                     for member in rs_status['members']:
                         if not member['stateStr'] == "ARBITER":
                             lastSlaveOpTime = member['optimeDate']
-                            replicationLag = abs(primary_node["optimeDate"] - lastSlaveOpTime).seconds - slaveDelays[member['name']]
+                            replicationLag = abs(primary_node["optimeDate"] - lastSlaveOpTime).total_seconds() - slaveDelays[member['name']]
                             data = data + member['name'] + " lag=%d;" % replicationLag
                             maximal_lag = max(maximal_lag, replicationLag)
                     if percent:


### PR DESCRIPTION
`total_seconds` is more accurate then `seconds`

```python
import datetime
x = datetime.datetime(2020,1,2)
y = datetime.datetime(2020,1,4)
(x-y).seconds  # 2
(x-y).total_seconds() # -172800.0
```

You are probably asking - "Why in the world do you have a replica set that has a lag of over a day?"

Well, we have such a long lag when we do initial syncs

