### PR TITLE
Actually pass auth_mechanism parameter to mongo_connect

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -200,7 +200,7 @@ def main(argv):
     # moving the login up here and passing in the connection
     #
     start = time.time()
-    err, con = mongo_connect(host, port, ssl, user, passwd, replicaset, authdb, insecure, ssl_ca_cert_file, cert_file, retry_writes_disabled=retry_writes_disabled)
+    err, con = mongo_connect(host, port, ssl, user, passwd, replicaset, authdb, insecure, ssl_ca_cert_file, cert_file, auth_mechanism, retry_writes_disabled)
 
     if err != 0:
         return err


### PR DESCRIPTION
`auth_mechanism` was added to the script arguments, but wasn't actually used in the script itself. The parameter now actually gets passed through to `mongo_connect`.