### PR TITLE
Update check_mongodb.py

### DIFF
--- a/check_mongodb.py
+++ b/check_mongodb.py
@@ -931,7 +931,10 @@ def check_collections(con, warning, critical, perf_data=None):
         for db in data['databases']:
             dbase = con[db['name']]
             set_read_preference(dbase)
-            count += len(dbase.collection_names())
+            if pymongo.version >= "3.7":
+                count += len(dbase.list_collection_names())
+            else:
+                count += len(dbase.collection_names())
 
         message = "Number of collections: %.0f" % count
         message += performance_data(perf_data, [(count, "collections", warning, critical, message)])


### PR DESCRIPTION
Added a pyMongo version check on line 934 and changed the handling of collection_names() since collection_names() has been deprecated since pyMongo version 3.7